### PR TITLE
feat: Incorporate logic for 'starring' favorite events

### DIFF
--- a/assets/styles/partials/_main.scss
+++ b/assets/styles/partials/_main.scss
@@ -131,6 +131,8 @@
         justify-content: space-between;
         align-items: center;
         background-color: #F4F4F4;
+        .glyphicon-star,
+        .glyphicon-star-empty { cursor: pointer; }
         .glyphicon-star { color: #F6DB3D; }
       }
     }

--- a/db/schemas/EventSchema.js
+++ b/db/schemas/EventSchema.js
@@ -32,6 +32,7 @@ const EventSchema = new Schema({
   photos: [EventPhotoSchema],
   tags: [EventTagSchema],
   links: [EventLinkSchema],
+  starred: Boolean,
   numRevisions: Number,
   archived: Boolean
 }, {

--- a/server/aaa.js
+++ b/server/aaa.js
@@ -23,24 +23,6 @@ const handleResponse = (err, data) => {
 
 // const sendResponse = (res, data) => { res.send(data); };
 
-
-exports.post = function(req, res) {
-  new Thread({title: req.body.title, author: req.body.author}).save();
-};
-
-// Perform Mongoose query to find all records that are instances of the Event
-//  Model, sort them in reverse chronological order (i.e., newest first),
-//  limit the sort to the 20 most recent records and pass the callback handler:
-const listEvents = (req, res) => {
-  Event
-    .find({})
-    .sort({ date: 'desc'})
-    .limit(20)
-    .exec((err, records) => {
-      res.send(records);
-    });
-};
-
 const getTLRange = (req, res) => {
   const minQuery = Event
     .find({})
@@ -120,25 +102,6 @@ const batchUpdate = (_ids) => {
 };
 
 
-// Perform
-const addEvents = (req, res, next) => {
-  const { name, date, location, description } = req.body;
-  const dd = { name, date, location, description };
-  console.log('Add Events Request Body:', req.body);
-
-  // Object
-  //   .keys(Event.schema.obj)
-  //   .forEach(datum => {
-  //     params[datum] = params[datum] || '';
-  //   });
-  new Event(dd).save((err) => {
-    if (err) {
-      res.status(400).send('SHIT YOOO');
-    } else {
-      res.json(dd);
-    }
-  });
-};
 // router.post('/tasks', function(req, res) {
 //   let newTask = new Task(req.body.taskParams);
 //   newTask.lastCompleted = null;
@@ -180,41 +143,6 @@ const addEvents = (req, res, next) => {
 //     .exec(handleResponse);
 // };
 
-/**
- * Edits a single instance of the Event model
- * @param {string} uuid - The UUID of the event record being edited
- * @param {object} evtProps - An object of property names and the corresponding edits
- * @return {promise} A Promise that resolves when the record has been edited
- */
-const updateSingleEvent = (req, res, next) => {
-  const { params: { id: evtId }, body: evtProps } = req;
-  console.log('\n\nREQ:', req);
-  Event
-    .findOneAndUpdate({ eventId: evtId }, evtProps)
-    .then(() => Event.findOne({ eventId: evtId }))
-    .then(evt => res.send(evt))
-    .catch(next);
-};
-
-
-// Perform
-const deleteEvents = (req, res, next) => {
-  const uuid = req.body.eventId;
-  console.log('AAA.js param:', uuid);
-
-  Event
-    .findOneAndRemove({ eventId: uuid }, (err, data) => {
-      if (err) {
-        console.error(`\nError: Failure to execute DELETE request.`);
-      } else {
-        console.log('\nDELETE request successful!');
-        res.json(data);
-      }
-    });
-    // .then(evt => res.status(204).send(evt))
-    // .then(evt => res.send(evt))
-    // .catch(next);
-};
 
 // const deleteEvent = (req, res) => {
 //   console.log('REQUEST BODY:', req.body);
@@ -228,25 +156,6 @@ const deleteEvents = (req, res, next) => {
 //     res.send(docs);
 //   });
 // });
-
-const deleteBatchEvents = (req, res, next) => {
-  console.log('\n\nBATCH DELETE req:', req);
-  const uuids = req.body;
-  Event
-    .remove({ uuid: { $in: uuids }})
-    .then(() => res.json(uuids))
-    .catch(next);
-};
-
-
-const getIndividualEvent = (req, res, next) => {
-  const sendResponse = (err, docs) => { res.send(docs); }
-  Event
-    .find({})
-    .limit(+req.params.eventId)
-    .sort({ date: 'desc' })
-    .exec(sendResponse);
-};
 
 module.exports = {
   addEvents,

--- a/server/aaa.js
+++ b/server/aaa.js
@@ -248,15 +248,6 @@ const getIndividualEvent = (req, res, next) => {
     .exec(sendResponse);
 };
 
-// App.get('/api/events/:id', (req, res, next) => {
-//   const sendResponse = (err, docs) => { res.send(docs); }
-//   Event
-//     .find({})
-//     .limit(+req.params.id)
-//     .sort('-date')
-//     .exec(sendResponse);
-// });
-
 module.exports = {
   addEvents,
   getIndividualEvent,
@@ -265,7 +256,3 @@ module.exports = {
   deleteEvents,
   deleteBatchEvents
 };
-
-
-
-

--- a/server/app.js
+++ b/server/app.js
@@ -13,7 +13,7 @@ const formatDate = require('./utilities');
 
 // const eventsRoute = require('./routes/events');
 
-const ApI = require('./aaa');
+const ApI = require('./controllers/EventsController');
 const seedData = require('../src/constants/json/SeedData.json');
 
 

--- a/server/controllers/EventsController.js
+++ b/server/controllers/EventsController.js
@@ -1,6 +1,110 @@
 'use strict';
+var Event = require('../../db/models/Event');
+const formatDate = require('../utilities');
+
+
+// Perform Mongoose query to find all records that are instances of the Event
+//  Model, sort them in reverse chronological order (i.e., newest first),
+//  limit the sort to the 20 most recent records and pass the callback handler:
+const listEvents = (req, res) => {
+  Event
+    .find({})
+    .sort({ date: 'desc'})
+    .limit(20)
+    .then(evts => res.send(evts))
+    .catch(err => {
+      res.status(400).send('Failed to fetch requested events!');
+      next();
+    });
+    // .exec((err, records) => {
+    //   res.send(records);
+    // });
+};
+
+
+const getSingleEvent = (req, res, next) => {
+  const sendResponse = (err, docs) => { res.send(docs); }
+  Event
+    .find({})
+    .limit(+req.params.eventId)
+    .sort({ date: 'desc' })
+    .then(evt => res.send(evt))
+    .catch(err => {
+      res.status(400).send('Failed to fetch requested event!');
+      next();
+    });
+};
+
+
+// Perform
+const addSingleEvent = (req, res, next) => {
+  const { name, date, location, description } = req.body;
+  const dd = { name, date, location, description };
+
+  // Object
+  //   .keys(Event.schema.obj)
+  //   .forEach(datum => {
+  //     params[datum] = params[datum] || '';
+  //   });
+  new Event(dd).save((err) => {
+    if (err) {
+      res.status(400).send('SHIT YOOO');
+    } else {
+      res.json(dd);
+    }
+  });
+};
+
+
+/**
+ * Edits a single instance of the Event model
+ * @param {string} uuid - The UUID of the event record being edited
+ * @param {object} evtProps - An object of property names and the corresponding edits
+ * @return {promise} A Promise that resolves when the record has been edited
+ */
+const updateSingleEvent = (req, res, next) => {
+  const { params: { id: evtId }, body: evtProps } = req;
+  Event
+    .findOneAndUpdate({ eventId: evtId }, evtProps)
+    .then(() => Event.findOne({ eventId: evtId }))
+    .then(evt => res.send(evt))
+    .catch(() => {
+      res.status(400).send('Failed to update specified event!');
+      next()
+    });
+};
+
+
+// Perform
+const deleteSingleEvent = (req, res, next) => {
+  const uuid = req.body.eventId;
+  Event
+    .findOneAndRemove({ eventId: uuid })
+    .then(() => res.json(uuid))
+    .catch(() => {
+      res.status(400).send('Failed to delete specified event!');
+      next();
+    });
+};
+
+
+const deleteBatchEvents = (req, res, next) => {
+  const uuids = req.body;
+  Event
+    .remove({ uuid: { $in: uuids }})
+    .then(() => res.json(uuids))
+    .catch(() => {
+      res.status(400).send('Failed to delete selected events!');
+      next();
+    });
+};
 
 
 module.exports = {
-  
+  getSingleEvent,
+  addSingleEvent,
+  listEvents,
+  updateSingleEvent,
+  deleteSingleEvent,
+  deleteBatchEvents  
 };

--- a/server/routes/eventIds.js
+++ b/server/routes/eventIds.js
@@ -3,14 +3,13 @@ const Express = require('express'),
       router = Express.Router(),
       BodyParser = require('body-parser'),
       parseUrlEncoded = BodyParser.urlencoded({ extended: false }),
-      ApI = require('../aaa');
+      EventController = require('../controllers/EventsController');
 
 
 router
   .route('/:id')
-  .get(ApI.getIndividualEvent)
-  .put(ApI.updateSingleEvent)
-  .delete(ApI.deleteEvents);
+  .get(EventController.getSingleEvent)
+  .put(EventController.updateSingleEvent)
+  .delete(EventController.deleteSingleEvent);
 
-// updateEvents
 module.exports = router;

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -3,13 +3,13 @@ const Express = require('express'),
       router = Express.Router(),
       BodyParser = require('body-parser'),
       parseUrlEncoded = BodyParser.urlencoded({ extended: false }),
-      ApI = require('../aaa');
+      EventController = require('../controllers/EventsController');
 
 
 router
   .route('/')
-  .get(ApI.listEvents)
-  .post(ApI.addEvents)
-  .delete(ApI.deleteBatchEvents);
+  .get(EventController.listEvents)
+  .post(EventController.addSingleEvent)
+  .delete(EventController.deleteBatchEvents);
 
 module.exports = router;

--- a/src/RouterConfig.jsx
+++ b/src/RouterConfig.jsx
@@ -3,23 +3,25 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { Router, Route } from 'react-router';
-
 import App from './components/pages/App';
 import TimelineEventPage from './components/pages/TimelineEventPage';
 import { fetchSeedData } from './actions/asyncActions';
 import { History, Store } from './store/configureStore';
 
 
-function loadEvts() {
-  Store.dispatch(fetchSeedData());
-}
+const loadEvts = () => Store.dispatch(fetchSeedData());
 
 // 
 const RouterConfig = () => (
   <Provider store={ Store }>
     <Router history={ History }>
-      <Route path="/" component={ App } onEnter={ loadEvts } />
-      <Route path="events/edit/:eventId" component={ TimelineEventPage } />
+      <Route
+        path="/"
+        component={ App }
+        onEnter={ loadEvts } />
+      <Route
+        path="events/edit/:eventId"
+        component={ TimelineEventPage } />
     </Router>
   </Provider>
 );
@@ -27,4 +29,7 @@ const RouterConfig = () => (
 export default RouterConfig;
 
 // Inject router configuration into HTML insertion <div>:
-ReactDOM.render(<RouterConfig />, document.getElementById('root'));
+ReactDOM.render(
+  <RouterConfig />,
+  document.getElementById('root')
+);

--- a/src/actions/asyncActions.js
+++ b/src/actions/asyncActions.js
@@ -35,6 +35,45 @@ export const fetchSeedData = () => {
 // };
 
 
+export const addNewEvent = (evtData) => {
+  return (dispatch) => {
+    return Axios
+      .post('/api/events', evtData)
+      .then(response => {
+        dispatch(addNewEventData(response.data));
+      })
+      .catch(err => {
+        throw new Error(`Error making POST request:\t${err}`);
+      });
+  };
+};
+
+// export const addNewEvent = (name, date, location, description) => {
+//   console.log('Async Action begun');
+//   const request = Axios.post('/api/events', {
+//     name,
+//     date,
+//     location,
+//     description
+//   });
+// };
+
+
+
+export const updateSingleEvent = (evtData) => {
+  return (dispatch) => {
+    return Axios
+      .put(`/api/events/edit/${evtData.eventId}`, evtData)
+      .then(response => {
+        dispatch(updateEventData(response.data));
+      })
+      .catch(err => {
+        throw new Error(`Error making PUT request:\t${err}`);
+      });
+  };
+};
+
+
 export const deleteSingleEvt = (evt) => {
   return (dispatch) => {
     return Axios
@@ -72,43 +111,6 @@ export const deleteBatchEvents = (evts) => {
   };
 };
 
-
-export const updateEvent = (evtData) => {
-  return (dispatch) => {
-    return Axios
-      .put(`/api/events/edit/${evtData.eventId}`, evtData)
-      .then(response => {
-        dispatch(updateEventData(response.data));
-      })
-      .catch(err => {
-        throw new Error(`Error making PUT request:\t${err}`);
-      });
-  };
-};
-
-
-export const addNewEvent = (evtData) => {
-  return (dispatch) => {
-    return Axios
-      .post('/api/events', evtData)
-      .then(response => {
-        dispatch(addNewEventData(response.data));
-      })
-      .catch(err => {
-        throw new Error(`Error making POST request:\t${err}`);
-      });
-  };
-};
-
-// export const addNewEvent = (name, date, location, description) => {
-//   console.log('Async Action begun');
-//   const request = Axios.post('/api/events', {
-//     name,
-//     date,
-//     location,
-//     description
-//   });
-// };
 
 // name: {
 //   type: String,

--- a/src/components/EditEventModal.jsx
+++ b/src/components/EditEventModal.jsx
@@ -13,9 +13,6 @@ import { updateEvent } from '../actions/asyncActions';
     eventEditingModalData: state.eventEditingModalData,
     eventEditingModalState: state.eventEditingModalState
   })
-  // dispatch => bindActionCreators({
-  //   updateEvent
-  // }, dispatch)
 )
 export default class EditEventModal extends Component {
   constructor(props) {
@@ -36,17 +33,13 @@ export default class EditEventModal extends Component {
   }
 
   updateEvent(name, date, location, description) {
-    console.log('\n\nMODAL DATA:', this.props.eventEditingModalData);
     const updatedData = {
       name: this.editEvtTitleInpt.value,
       date: this.editEvtDateInpt.value,
       location: this.editEvtLocationInpt.value,
       description: this.editEvtDescriptionInpt.value
     };
-
     const newEvtData = Object.assign({}, this.props.eventEditingModalData, updatedData);
-    console.log('\n\nNEW EVENT DATA:', newEvtData);
-
     this.props.updEvt(newEvtData);
     this.props.toggleModal();
   }

--- a/src/components/NewEventModal.jsx
+++ b/src/components/NewEventModal.jsx
@@ -8,17 +8,13 @@ import FileUploadAPI from './FileUploadAPI';
 import { addNewEvent } from '../actions/asyncActions';
 
 
-// @connect(
-//   null,
-//   (dispatch) => bindActionCreators({ addNewEvent }, dispatch)
-// )
 export default class NewEventModal extends Component {
   constructor(props) {
     super(props);
   }
 
   saveNewEvt(name, date, location, description) {
-    this.props.adddder({
+    this.props.addNewEvent({
       name: this.newEvtTitleInpt.value,
       date: this.newEvtDateInpt.value,
       location: this.newEvtLocationInpt.value,
@@ -29,7 +25,6 @@ export default class NewEventModal extends Component {
 
   componentWillReceiveProps(nextProps) {
     const self = this;
-
     if (this.props.modalStatus !== nextProps.modalStatus && nextProps.modalStatus) {
       setTimeout(function() {
         self.newEvtDateInpt.valueAsDate = new Date();
@@ -125,5 +120,3 @@ export default class NewEventModal extends Component {
     );
   }
 };
-
-// export default NewEventModal;

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -50,36 +50,16 @@ export default class Timeline extends Component {
       : $('body').removeClass('modal-active');
   }
   
-  toggleNewEvtModal() {
-    this.setState({ newModal: !this.state.newModal });
-  }
+  // toggleNewEvtModal() {
+  //   this.setState({ newModal: !this.state.newModal });
+  // }
 
-  logModalData(data) { this.props.logEventModalData(data); }
-
-  deleteTLEvt(evt) {
-    this.props.deleteSingleEvt(evt);
-  }
-
-  adddder(evtData) {
-    this.props.addNewEvent(evtData);
-  }
-
-  updEvt(evtData) {
-    this.props.updateEvent(evtData);
-  }
+  // logModalData(data) { this.props.logEventModalData(data); }
 
   orderTimelineEvents(evts) {
     return evts && evts.length
       ? evts.sort((evt1, evt2) => Utils.getTimeDifferenceInMs(evt2.date, evt1.date))
       : [];
-  }
-
-  toggleBatchSelection(bool = undefined) {
-    this.props.allowBatchSelection(bool);
-  }
-
-  addSelectionToBatch(evtUuid) {
-    this.props.addEventToBatchSelection(evtUuid);
   }
 
   deleteBatch() {
@@ -100,11 +80,11 @@ export default class Timeline extends Component {
         evtFormattedDate={ evt.formattedDate }
         evtNote={ evt.type }
         photoCount={ evt.photoCount }
-        logModalData={ ::this.logModalData }
+        logModalData={ (data) => this.props.logEventModalData(data) }
         toggleModal={ ::this.toggleModal }
-        deleteEvt={ ::this.deleteTLEvt }
+        deleteEvt={ (evt) => this.props.deleteSingleEvt(evt) }
         batchSelectionState={ this.props.batchSelectionState }
-        addSelectionToBatch={ ::this.addSelectionToBatch } />
+        addSelectionToBatch={ (evtUuid) => this.props.addEventToBatchSelection(evtUuid) } />
     );
   }
 
@@ -129,18 +109,18 @@ export default class Timeline extends Component {
           modalData={ this.props.eventEditingModalData }
           modalStatus={ this.props.eventEditingModalState }
           toggleModal={ ::this.toggleModal }
-          updEvt={ ::this.updEvt } />
+          updEvt={ (evtData) => this.props.updateEvent(evtData) } />
         <NewEventModal
           modalStatus={ this.state.newModal }
-          toggleModal={ ::this.toggleNewEvtModal }
-          adddder={ ::this.adddder } />
+          toggleModal={ () => this.setState({ newModal: !this.state.newModal }) }
+          addNewEvent={ (evtData) => this.props.addNewEvent(evtData) } />
         <BatchActionButtons
           batchSelectionState={ this.props.batchSelectionState }
-          toggleBatchSelection={ ::this.toggleBatchSelection }
+          toggleBatchSelection={ (bool = undefined) => this.props.allowBatchSelection(bool) }
           deleteBatch={ ::this.deleteBatch } />
         <ButtonControls
-          toggleModal={ ::this.toggleNewEvtModal }
-          toggleBatchSelection={ ::this.toggleBatchSelection } />
+          toggleModal={ () => this.setState({ newModal: !this.state.newModal }) }
+          toggleBatchSelection={ (bool = undefined) => this.props.allowBatchSelection(bool) } />
       </div>
     );
   }

--- a/src/components/tl-event/TLEventFooter.jsx
+++ b/src/components/tl-event/TLEventFooter.jsx
@@ -2,17 +2,19 @@
 import React from 'react';
 
 
-const TLEventFooter = ({ evtNote }) => (
+const TLEventFooter = ({ evt, evtNote, addEventToFavorites, getStarGlyphClass, hasMultipleTags }) => (
   <div className="panel-footer">
     <div className="evt-tags">
       {[
         <i
           key={ `TagsGlyph` }
-          className="glyphicon glyphicon-tags" />,
+          className={ `glyphicon glyphicon-tag${hasMultipleTags ? 's' : ''}` } />,
         evtNote
       ]}
     </div>
-    <i className="glyphicon glyphicon-star-empty" />
+    <i
+      className={ `glyphicon glyphicon-star${getStarGlyphClass ? '' : '-empty'}` }
+      onClick={ () => addEventToFavorites(evt) } />
   </div>
 );
 

--- a/src/components/tl-event/TimelineEvent.jsx
+++ b/src/components/tl-event/TimelineEvent.jsx
@@ -23,7 +23,7 @@ import TLEventFooter from './TLEventFooter';
 // };
 
 
-const TimelineEvent = ({ evt, evtName, evtLocation, evtAlign, evtDescription, evtDate, evtFormattedDate, evtNote, photoCount, logModalData, toggleModal, deleteEvt, batchSelectionState, addSelectionToBatch }) => (
+const TimelineEvent = ({ evt, evtName, evtLocation, evtAlign, evtDescription, evtDate, evtFormattedDate, evtNote, photoCount, logModalData, toggleModal, deleteEvt, batchSelectionState, addSelectionToBatch, addEventToFavorites, getStarGlyphClass, hasMultipleTags }) => (
   <li className={ `tl-event${evtAlign}` }>
     <div className="tl-marker">
       <i className="glyphicon glyphicon-record" />
@@ -46,7 +46,11 @@ const TimelineEvent = ({ evt, evtName, evtLocation, evtAlign, evtDescription, ev
         photoCount={ photoCount }
         evtFormattedDate={ evtFormattedDate } />
       <TLEventFooter
-        evtNote={ evtNote } />
+        evt={ evt }
+        evtNote={ evtNote }
+        addEventToFavorites={ addEventToFavorites }
+        getStarGlyphClass={ getStarGlyphClass }
+        hasMultipleTags={ hasMultipleTags } />
     </div>
   </li>
 );

--- a/src/reducers/batchSelectionItems.js
+++ b/src/reducers/batchSelectionItems.js
@@ -6,17 +6,17 @@ export default function batchSelectionItems(state = [], action = null) {
   switch (action.type) {
     
     case ADD_EVENT_TO_BATCH:
-      console.log(`Action <${action.type}> executed with payload `, action.payload);
+      // console.log(`Action <${action.type}> executed with payload `, action.payload);
       if (state.includes(action.payload)) {
         let newState = Array.of(...state),
             removalIndex = state.findIndex(evt => evt === action.payload);
         newState.splice(removalIndex, 1);
         return newState;
       }
-      return state.concat(action.payload);
+      return [...state, action.payload];
       
     case CLEAR_BATCH:
-      console.log(`Action <${action.type}> executed with empty payload.`);
+      // console.log(`Action <${action.type}> executed with empty payload.`);
       state = [];
       
     default:

--- a/src/reducers/batchSelectionState.js
+++ b/src/reducers/batchSelectionState.js
@@ -6,7 +6,7 @@ export default function batchSelectionState(state = false, action = null) {
   switch (action.type) {
 
     case ALLOW_BATCH_SELECTION:
-      console.log(`Action <${action.type}> executed with payload `, action.payload);
+      // console.log(`Action <${action.type}> executed with payload `, action.payload);
       return action.payload === undefined
         ? !state
         : action.payload;

--- a/src/reducers/seedDataAggregator.js
+++ b/src/reducers/seedDataAggregator.js
@@ -12,7 +12,7 @@ export default function seedDataAggregator(state = [], action = null) {
 
     case ADD_NEW_EVENT_DATA:
       // console.log(`Action <${action.type}> executed with payload `, action.payload);
-      return new Array(...state).concat(action.payload);
+      return [...state, action.payload];
 
     case DELETE_SINGLE_EVENT:
       // console.log(`Action <${action.type}> executed with payload `, action.payload);
@@ -33,7 +33,7 @@ export default function seedDataAggregator(state = [], action = null) {
       const updatedEvtIndex = state.findIndex(evt => evt.uuid === action.payload.uuid);
       newState = Array.of(...state);
       newState.splice(updatedEvtIndex, 1);
-      return newState.concat(action.payload);
+      return [...newState, action.payload];
 
     default:
       return state;

--- a/src/reducers/seedDataAggregator.js
+++ b/src/reducers/seedDataAggregator.js
@@ -14,6 +14,13 @@ export default function seedDataAggregator(state = [], action = null) {
       // console.log(`Action <${action.type}> executed with payload `, action.payload);
       return [...state, action.payload];
 
+    case UPDATE_EVENT_DATA:
+      // console.log(`Action <${action.type}> executed with payload `, action.payload);
+      const updatedEvtIndex = state.findIndex(evt => evt.uuid === action.payload.uuid);
+      newState = Array.of(...state);
+      newState.splice(updatedEvtIndex, 1);
+      return [...newState, action.payload];
+
     case DELETE_SINGLE_EVENT:
       // console.log(`Action <${action.type}> executed with payload `, action.payload);
       const removedEvtUuid = state.findIndex(evt => evt.uuid === action.payload.uuid);
@@ -27,13 +34,6 @@ export default function seedDataAggregator(state = [], action = null) {
         .of(...state)
         .filter(evt => !action.payload.includes(evt.uuid));
       return newState;
-
-    case UPDATE_EVENT_DATA:
-      // console.log(`Action <${action.type}> executed with payload `, action.payload);
-      const updatedEvtIndex = state.findIndex(evt => evt.uuid === action.payload.uuid);
-      newState = Array.of(...state);
-      newState.splice(updatedEvtIndex, 1);
-      return [...newState, action.payload];
 
     default:
       return state;

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -3,9 +3,9 @@ import Webpack from 'webpack';
 import Merge from 'webpack-merge';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import HTMLWebpackPlugin from 'html-webpack-plugin';
+import DotEnv from 'dotenv-webpack';
 import Path from 'path';
 import PostCSS from './postcss.config';
-import DotEnv from 'dotenv-webpack';
 
 
 // const appEnv = (process.env.NODE_ENV || 'dev');
@@ -20,17 +20,20 @@ const VENDOR_LIBS = [
   'lodash',
   'react',
   'react-dom',
+  'react-motion',
   'react-redux',
   'react-router',
   'react-router-redux',
   'redux',
-  'redux-thunk'
+  'redux-thunk',
+  'request',
+  'uuid'
 ];
 
 const BASE_CONFIG = {
   entry: {
     // 'webpack/hot/dev-server',
-    bundle: Path.resolve(__dirname, 'src/Routes'),
+    bundle: Path.resolve(__dirname, 'src/RouterConfig'),
     vendor: VENDOR_LIBS
   },
   output: {


### PR DESCRIPTION
## Summary of Changes

+ New functionality aside, the bulk of this PR consists largely of various chores performed in an effort to maintain the overall organization of the application's logic as well as to aid future developers in navigating the app in an intuitive manner. Among these chores are:
  - Comment-out `console.log()` statements within the Redux reducers. These pure functions have been tested for most use cases and are stable enough not to require logging at this point in time. In anticipation of any future debugging, I have only commented them out so that they may quickly be reenabled to help developers through the stack traces.
  - Replace class methods inside the parent `Timeline` component with their equivalent ES6 fat arrow functions. Inlining these functions helps reduce code bloat and more quickly navigate the (quickly growing) component file [Ref. _src/components/Timeline.jsx_].
+ Add the `cursor: pointer;` property-value pair to the `glyphicon-star-*` class inside the event footer.
+ Include logic allowing one to reversibly _favorite_ (_i.e._, star) any particular event. This action is reflected both in the MongoDB document as well as on the front-end.